### PR TITLE
Fix linux-arm7neonhf build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ ifeq ($(STATIC_LINKING), 1)
 EXT := a
 endif
 
-ifeq ($(platform), unix)
+ifneq (,$(findstring unix,$(platform)))
 	EXT ?= so
    TARGET := $(TARGET_NAME)_libretro.$(EXT)
    fpic := -fPIC


### PR DESCRIPTION
- [Buildbot](http://paste.libretro.com/170782) is using `platform=unix-armv7-hardfloat-neon` for linux-arm7neonhf build

- So now it matches platform which contains `unix` not strictly `unix`