### PR TITLE
Replace strcasecmp

### DIFF
--- a/src/path.cpp
+++ b/src/path.cpp
@@ -1,4 +1,5 @@
 #include <retro_miscellaneous.h>
+#include <string/stdstring.h>
 
 #include "path.h"
 
@@ -90,6 +91,6 @@ std::string make_path(const char* path, const char* filename)
 
 bool string_compare_insensitive(const char* a, const char* b)
 {
-    return (strcasecmp(a, b) == 0);
+    return string_is_equal_case_insensitive(a, b);
 }
 


### PR DESCRIPTION
- Attempt to fix [Libnx compilation issue](http://paste.libretro.com/170912) by using [string_is_equal_case_insensitive](https://github.com/libretro/libretro-common/blob/master/include/string/stdstring.h#L55-L72) instead of strcasecmp.