### PR TITLE
Add Android build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ CMakeFiles/
 CMakeCache.txt
 cmake_install.cmake
 .vscode
+*.o
+*.so

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,0 +1,25 @@
+LOCAL_PATH := $(call my-dir)
+
+CORE_DIR   := $(LOCAL_PATH)/..
+
+include $(CORE_DIR)/Makefile.common
+
+COREFLAGS := -DINLINE=inline -D__LIBRETRO__
+COREFLAGS += -DHAVE_CHD -DHAVE_COMPRESSION -DHAVE_ZLIB -DHAVE_7ZIP -D_7ZIP_ST
+COREFLAGS += -DHAVE_FLAC -DFLAC__HAS_OGG=0 -DFLAC_API_EXPORTS -DFLAC__NO_DLL
+COREFLAGS += -DHAVE_LROUND -DHAVE_STDINT_H -DHAVE_STDLIB_H -DHAVE_SYS_PARAM_H
+
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+   COREFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
+include $(CLEAR_VARS)
+LOCAL_MODULE    := retro
+LOCAL_SRC_FILES := $(SOURCES_CXX) $(SOURCES_C)
+LOCAL_CXXFLAGS  := -fomit-frame-pointer -std=c++11 -fno-exceptions -fno-rtti $(COREFLAGS) $(INCFLAGS)
+LOCAL_CFLAGS    := -fomit-frame-pointer $(COREFLAGS) $(INCFLAGS)
+LOCAL_LDFLAGS   := -Wl,-version-script=$(CORE_DIR)/link.T
+LOCAL_LDLIBS    := -lz
+LOCAL_ARM_MODE  := arm
+include $(BUILD_SHARED_LIBRARY)

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,0 +1,3 @@
+APP_STL := c++_static
+APP_ABI := all
+APP_PLATFORM := android-19


### PR DESCRIPTION
This PR just adds the jni files required for building the Android version of the core.

I've tested the `armeabi-v7a` and `x86` builds - everything seems to work correctly.