### PR TITLE
Revert "Pinpoint C standard to std=c99 to prevent different semantics of uint…"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ else
    CXXFLAGS += -Ofast -fomit-frame-pointer
 endif
 
-CFLAGS += -std=c99 -DHAVE_COMPRESSION -DHAVE_ZLIB -DHAVE_7ZIP -D_7ZIP_ST -DHAVE_FLAC
+CFLAGS += -DHAVE_COMPRESSION -DHAVE_ZLIB -DHAVE_7ZIP -D_7ZIP_ST -DHAVE_FLAC
 CXXFLAGS += -std=c++11 -fno-exceptions -fno-rtti
 
 include Makefile.common


### PR DESCRIPTION
Reverts libretro/neocd_libretro#46