### PR TITLE
Reduce latency by adjusting emulated frame slice boundary

### DIFF
--- a/src/neogeocd.h
+++ b/src/neogeocd.h
@@ -53,14 +53,23 @@ public:
     void clearInterrupt(NeoGeoCD::Interrupt interrupt);
     int  updateInterrupts();
 
+#define ADJUST_FRAME_BOUNDARY
     inline int  getScreenX() const
     {
+#ifndef ADJUST_FRAME_BOUNDARY
         return (Timer::masterToPixel(Timer::CYCLES_PER_FRAME - remainingCyclesThisFrame) % Timer::SCREEN_WIDTH);
+#else
+        return (Timer::VBL_IRQ_X + Timer::masterToPixel(Timer::CYCLES_PER_FRAME - remainingCyclesThisFrame)) % Timer::SCREEN_WIDTH;
+#endif
     }
 
     inline int  getScreenY() const
     {
+#ifndef ADJUST_FRAME_BOUNDARY
         return (Timer::masterToPixel(Timer::CYCLES_PER_FRAME - remainingCyclesThisFrame) / Timer::SCREEN_WIDTH);
+#else
+        return (Timer::VBL_IRQ_Y + (Timer::VBL_IRQ_X + Timer::masterToPixel(Timer::CYCLES_PER_FRAME - remainingCyclesThisFrame)) / Timer::SCREEN_WIDTH) % Timer::SCREEN_HEIGHT;
+#endif
     }
 
     inline bool isCdDecoderIRQEnabled() const

--- a/src/timergroup.cpp
+++ b/src/timergroup.cpp
@@ -212,13 +212,21 @@ void TimerGroup::reset()
 {
     timer<TimerGroup::Watchdog>().setState(Timer::Stopped);
 
+#ifndef ADJUST_FRAME_BOUNDARY
     timer<TimerGroup::Drawline>().arm(Timer::pixelToMaster(Timer::ACTIVE_AREA_LEFT));
 
     timer<TimerGroup::Vbl>().arm(Timer::pixelToMaster((Timer::VBL_IRQ_Y * Timer::SCREEN_WIDTH) + Timer::VBL_IRQ_X));
 
-    timer<TimerGroup::Hbl>().setState(Timer::Stopped);
-
     timer<TimerGroup::VblReload>().arm(Timer::pixelToMaster((Timer::VBL_RELOAD_Y * Timer::SCREEN_WIDTH) + Timer::VBL_RELOAD_X));
+#else
+    timer<TimerGroup::Drawline>().arm(Timer::pixelToMaster(Timer::ACTIVE_AREA_LEFT - Timer::VBL_IRQ_X));
+
+    timer<TimerGroup::Vbl>().arm(Timer::pixelToMaster(Timer::SCREEN_WIDTH * Timer::SCREEN_HEIGHT));
+
+    timer<TimerGroup::VblReload>().arm(Timer::pixelToMaster((Timer::VBL_RELOAD_Y - Timer::VBL_IRQ_Y) * Timer::SCREEN_WIDTH + (Timer::VBL_RELOAD_X - Timer::VBL_IRQ_X)));
+#endif
+
+    timer<TimerGroup::Hbl>().setState(Timer::Stopped);
 
     timer<TimerGroup::Cdrom>().arm(Timer::CDROM_64HZ_DELAY);
 


### PR DESCRIPTION
this is the same issue i recently addressed in FBNeo, which you can see here for details about how it works and why it's important: https://github.com/finalburnneo/FBNeo/pull/1029
it was much MUCH easier to apply this same adjustment on this emulator due to its code being so INCREDIBLY clean and easy to understand.  and i say this as someone who's an ardent C devotee that hates C++ with a passion.. if everyone could produce C++ like this i'd probably feel differently

edit:
i also have this same adjustment implemented w/o using a define variable in a branch over here, which i can pull request instead if that's preferable: https://github.com/energy-t/neocd_libretro/tree/reduce-latency-clean