### PR TITLE
use emar for archiving instead of emcc/em++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ else ifneq (,$(findstring qnx,$(platform)))
 else ifeq ($(platform), emscripten)
    TARGET := $(TARGET_NAME)_libretro_emscripten.bc
    fpic := -fPIC
+   AR=emar
    SHARED :=
    CFLAGS += -DSYNC_CDROM=1
    CXXFLAGS += -DSYNC_CDROM=1
@@ -245,7 +246,7 @@ ifneq ($(GIT_VERSION)," unknown")
 endif
 
 CFLAGS += -DHAVE_ZLIB -D_7ZIP_ST -DHAVE_FLAC -DUSE_LIBRETRO_VFS
-CXXFLAGS += -std=c++11 -fno-exceptions -fno-rtti -DUSE_LIBRETRO_VFS
+CXXFLAGS += -std=c++14 -fno-exceptions -fno-rtti -DUSE_LIBRETRO_VFS
 
 include Makefile.common
 
@@ -257,10 +258,7 @@ CXXFLAGS += -Wall -D__LIBRETRO__ $(fpic) $(INCFLAGS)
 all: $(TARGET)
 
 $(TARGET): $(OBJECTS)
-ifeq ($(platform), emscripten)
-	@$(if $(Q), $(shell echo echo LD $@),)
-	$(CXX) $(fpic) -r $(SHARED) -o $@ $(OBJECTS) $(LIBS) $(LDFLAGS)
-else ifeq ($(STATIC_LINKING), 1)
+ifeq ($(STATIC_LINKING), 1)
 	$(AR) rcs $@ $(OBJECTS)
 else
 	@$(if $(Q), $(shell echo echo LD $@),)

--- a/src/audiobuffer.h
+++ b/src/audiobuffer.h
@@ -20,7 +20,7 @@ public:
     static constexpr double SAMPLES_PER_FRAME = static_cast<double>(SAMPLE_RATE) / Timer::FRAME_RATE;
 
     /// The audio buffer size, enough for one frame of audio.
-    static constexpr uint32_t CD_BUFFER_SIZE = round<int32_t>(SAMPLES_PER_FRAME + 1.0);
+    static constexpr uint32_t CD_BUFFER_SIZE = round<uint32_t, double>(SAMPLES_PER_FRAME + 1.0);
 
     /// We may occasionally generate one or two extra samples because of a long instruction (like DIVU)
     static constexpr uint32_t YM_BUFFER_SIZE = CD_BUFFER_SIZE + 2;

--- a/src/timer.h
+++ b/src/timer.h
@@ -28,13 +28,13 @@ public:
     static constexpr int32_t VBL_RELOAD_X = ACTIVE_AREA_RIGHT - 63;
     static constexpr int32_t VBL_RELOAD_Y = ACTIVE_AREA_BOTTOM;
 
-    static constexpr int32_t WATCHDOG_DELAY = round<int32_t>(MASTER_CLOCK * 0.13516792);
-    static constexpr int32_t CDROM_64HZ_DELAY = round<int32_t>(MASTER_CLOCK / 64.64);
-    static constexpr int32_t CDROM_75HZ_DELAY = round<int32_t>(MASTER_CLOCK / 75.0);
-    static constexpr int32_t CDROM_150HZ_DELAY = round<int32_t>(MASTER_CLOCK / 150.0);
+  static constexpr int32_t WATCHDOG_DELAY = round<int32_t, double>(MASTER_CLOCK * 0.13516792);
+  static constexpr int32_t CDROM_64HZ_DELAY = round<int32_t, double>(MASTER_CLOCK / 64.64);
+  static constexpr int32_t CDROM_75HZ_DELAY = round<int32_t, double>(MASTER_CLOCK / 75.0);
+  static constexpr int32_t CDROM_150HZ_DELAY = round<int32_t, double>(MASTER_CLOCK / 150.0);
 
     static constexpr double FRAME_RATE = PIXEL_CLOCK / static_cast<double>(SCREEN_WIDTH * SCREEN_HEIGHT);
-    static constexpr int32_t CYCLES_PER_FRAME = round<int32_t>((MASTER_CLOCK / PIXEL_CLOCK) * SCREEN_WIDTH * SCREEN_HEIGHT);
+  static constexpr int32_t CYCLES_PER_FRAME = round<int32_t, double>((MASTER_CLOCK / PIXEL_CLOCK) * SCREEN_WIDTH * SCREEN_HEIGHT);
 
     typedef void(*Callback)(Timer* timer, uint32_t userData);
 
@@ -64,7 +64,7 @@ public:
 
     static inline constexpr int32_t secondsToMaster(double value)
     {
-        return round<int32_t>(value * MASTER_CLOCK);
+      return round<int32_t, double>(value * MASTER_CLOCK);
     }
 
     static inline constexpr double masterToSeconds(int32_t value)


### PR DESCRIPTION
I also had to make some template arguments explicit.

Per https://github.com/libretro/RetroArch/pull/15688